### PR TITLE
Add navigation and about section to landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# Lucia_zallocco
+# Lucia Zallocco Landing Page
+
+Landing page de asesoramiento de marketing y diseño de marca para Lucia Zallocco. Incluye servicios, casos de éxito y formulario de contacto.
+
+## Uso
+
+Abre `index.html` en un navegador para visualizar el sitio.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,166 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Lucia Zallocco - Branding con propósito</title>
+    <meta
+      name="description"
+      content="Branding, gestión de redes sociales y alineación con ODS para marcas con propósito."
+    />
+    <meta
+      name="keywords"
+      content="branding, marketing digital, redes sociales, ODS, sostenibilidad, Lucia Zallocco"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body id="top">
+    <header class="hero">
+      <nav class="top-nav">
+        <a href="#top" class="logo">Lucia Zallocco</a>
+        <div class="nav-links">
+          <a href="#servicios">Servicios</a>
+          <a href="#acerca">Acerca de mí</a>
+          <a href="#contacto">Contacto</a>
+        </div>
+      </nav>
+      <div class="hero-content">
+        <h1>Impulsamos tu marca con propósito, creatividad y resultados</h1>
+        <h2>
+          Branding personalizado, gestión de redes sociales y alineación con ODS
+        </h2>
+        <a href="#contacto" class="btn-primary">Agenda tu consulta gratuita</a>
+      </div>
+    </header>
+
+    <main>
+      <section class="problema-solucion" id="servicios">
+        <h2>Si tu marca no conecta, no crece</h2>
+        <p>
+          Te ayudamos a superar los retos de identidad, presencia digital y
+          sostenibilidad que limitan tu crecimiento.
+        </p>
+        <div class="cards">
+          <article class="card">
+            <span class="icon">🎨</span>
+            <h3>Branding personalizado</h3>
+            <p>
+              Diseñamos identidades únicas y consistentes que reflejan la
+              esencia de tu negocio.
+            </p>
+          </article>
+          <article class="card">
+            <span class="icon">📱</span>
+            <h3>Creación y gestión de RRSS</h3>
+            <p>
+              Contenido estratégico que conecta y construye comunidades
+              comprometidas.
+            </p>
+          </article>
+          <article class="card">
+            <span class="icon">🌱</span>
+            <h3>Alineación con ODS y reputación</h3>
+            <p>
+              Integración de prácticas sostenibles para fortalecer tu
+              posicionamiento.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section class="acerca" id="acerca">
+        <h2>Acerca de mí</h2>
+        <p>
+          Soy Lucia Zallocco, especialista en branding y marketing digital con
+          enfoque sostenible.
+        </p>
+      </section>
+
+      <section class="beneficios">
+        <ul>
+          <li><span class="check">✔</span>Marca coherente y memorable</li>
+          <li>
+            <span class="check">✔</span>Redes sociales que generan comunidad
+          </li>
+          <li>
+            <span class="check">✔</span>Reputación sólida alineada con
+            sostenibilidad
+          </li>
+        </ul>
+      </section>
+
+      <section class="portfolio" id="portfolio">
+        <h2>Casos de éxito</h2>
+        <div class="grid">
+          <img src="https://via.placeholder.com/400x300" alt="Proyecto 1" />
+          <img src="https://via.placeholder.com/400x300" alt="Proyecto 2" />
+          <img src="https://via.placeholder.com/400x300" alt="Proyecto 3" />
+          <img src="https://via.placeholder.com/400x300" alt="Proyecto 4" />
+        </div>
+      </section>
+
+      <section class="testimonios">
+        <h2>Testimonios</h2>
+        <div class="testimonio-cards">
+          <article class="testimonio">
+            <img src="https://via.placeholder.com/80" alt="Cliente 1" />
+            <blockquote>
+              “Gracias a Lucia, nuestra marca encontró su voz y propósito.”
+            </blockquote>
+            <p class="cliente">María Pérez</p>
+          </article>
+          <article class="testimonio">
+            <img src="https://via.placeholder.com/80" alt="Cliente 2" />
+            <blockquote>
+              “La estrategia en redes elevó nuestra comunidad a otro nivel.”
+            </blockquote>
+            <p class="cliente">Juan López</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="propuesta">
+        <h2>
+          Somos el puente entre creatividad, estrategia digital y sostenibilidad
+        </h2>
+        <a href="#contacto" class="btn-secondary">Conoce nuestro enfoque</a>
+      </section>
+
+      <section class="contacto" id="contacto">
+        <h2>Contacto</h2>
+        <form action="https://formspree.io/f/xayzeqln" method="POST">
+          <input type="text" name="nombre" placeholder="Nombre" required />
+          <input type="email" name="email" placeholder="Email" required />
+          <textarea name="mensaje" placeholder="Mensaje" required></textarea>
+          <button type="submit" class="btn-primary">Enviar</button>
+        </form>
+        <div class="contact-links">
+          <a href="https://wa.me/123456789" class="btn-secondary">WhatsApp</a>
+          <a href="https://calendly.com/" class="btn-secondary">Calendly</a>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <nav class="footer-nav">
+        <a href="#top">Inicio</a>
+        <a href="#servicios">Servicios</a>
+        <a href="#acerca">Acerca de mí</a>
+        <a href="#portfolio">Portfolio</a>
+        <a href="#contacto">Contacto</a>
+      </nav>
+      <div class="social">
+        <a href="#"><span class="icon">🐦</span></a>
+        <a href="#"><span class="icon">📸</span></a>
+        <a href="#"><span class="icon">💼</span></a>
+      </div>
+      <p>Creando marcas con propósito</p>
+    </footer>
+  </body>
+</html>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow:
+

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,253 @@
+:root {
+  --beige: #f5f5dc;
+  --green: #3a6b35;
+  --brown: #4e342e;
+  --coral: #ff6f61;
+  --light-green: #e8f5e9;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: "Poppins", sans-serif;
+  background-color: var(--beige);
+  color: var(--brown);
+  line-height: 1.6;
+}
+
+.top-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 20px;
+}
+
+.top-nav .logo {
+  font-weight: 600;
+  color: var(--beige);
+  text-decoration: none;
+}
+
+.top-nav .nav-links a {
+  color: var(--beige);
+  margin-left: 15px;
+  text-decoration: none;
+  font-weight: 300;
+}
+
+.top-nav .nav-links a:hover {
+  text-decoration: underline;
+}
+
+.hero {
+  background:
+    linear-gradient(rgba(78, 52, 46, 0.7), rgba(58, 107, 53, 0.7)),
+    url("https://via.placeholder.com/1600x900") center/cover no-repeat;
+  color: var(--beige);
+  text-align: center;
+  padding: 100px 20px;
+}
+
+.hero-content h1 {
+  font-size: 2.5rem;
+  margin-bottom: 20px;
+}
+
+.hero-content h2 {
+  font-weight: 300;
+  margin-bottom: 30px;
+}
+
+.btn-primary,
+.btn-secondary {
+  display: inline-block;
+  padding: 12px 25px;
+  border-radius: 4px;
+  text-decoration: none;
+  transition: background 0.3s;
+  font-weight: 600;
+}
+
+.btn-primary {
+  background: var(--coral);
+  color: #fff;
+}
+
+.btn-primary:hover {
+  background: #ff856f;
+}
+
+.btn-secondary {
+  background: transparent;
+  border: 2px solid var(--green);
+  color: var(--green);
+}
+
+.btn-secondary:hover {
+  background: var(--green);
+  color: #fff;
+}
+
+.problema-solucion {
+  text-align: center;
+  padding: 60px 20px;
+}
+
+.acerca {
+  text-align: center;
+  padding: 60px 20px;
+}
+
+.acerca p {
+  max-width: 600px;
+  margin: 20px auto 0;
+}
+
+.problema-solucion .cards {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  margin-top: 40px;
+}
+
+.card {
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+.icon {
+  font-size: 2rem;
+  display: block;
+  margin-bottom: 10px;
+}
+
+.beneficios {
+  background: var(--light-green);
+  padding: 40px 20px;
+}
+
+.beneficios ul {
+  max-width: 600px;
+  margin: 0 auto;
+  list-style: none;
+}
+
+.beneficios li {
+  margin-bottom: 10px;
+  font-size: 1.1rem;
+}
+
+.check {
+  color: var(--green);
+  margin-right: 8px;
+}
+
+.portfolio {
+  padding: 60px 20px;
+  text-align: center;
+}
+
+.portfolio .grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 20px;
+  margin-top: 30px;
+}
+
+.portfolio img {
+  width: 100%;
+  border-radius: 8px;
+}
+
+.testimonios {
+  background: #fff;
+  padding: 60px 20px;
+  text-align: center;
+}
+
+.testimonio-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 20px;
+  margin-top: 30px;
+}
+
+.testimonio {
+  background: var(--beige);
+  padding: 20px;
+  border-radius: 8px;
+}
+
+.testimonio img {
+  border-radius: 50%;
+  margin-bottom: 15px;
+}
+
+.propuesta {
+  background: var(--green);
+  color: var(--beige);
+  text-align: center;
+  padding: 60px 20px;
+}
+
+.contacto {
+  padding: 60px 20px;
+  text-align: center;
+}
+
+.contacto form {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+  max-width: 500px;
+  margin: 0 auto 20px;
+}
+
+.contacto input,
+.contacto textarea {
+  padding: 10px;
+  border: 1px solid var(--brown);
+  border-radius: 4px;
+}
+
+.contact-links {
+  display: flex;
+  justify-content: center;
+  gap: 15px;
+  flex-wrap: wrap;
+}
+
+footer {
+  background: var(--brown);
+  color: var(--beige);
+  text-align: center;
+  padding: 20px 10px;
+}
+
+.footer-nav {
+  margin-bottom: 10px;
+}
+
+.footer-nav a {
+  color: var(--beige);
+  margin: 0 10px;
+  text-decoration: none;
+}
+
+.social a {
+  color: var(--beige);
+  margin: 0 5px;
+  font-size: 1.2rem;
+}
+
+@media (max-width: 600px) {
+  .hero-content h1 {
+    font-size: 2rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add top navigation with links to services, about and contact
- introduce dedicated "Acerca de mí" section and corresponding styles
- document project and include robots.txt for basic SEO

## Testing
- `npx --yes prettier --check index.html styles.css README.md`
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af4a3b57a0832b890d6fc2a6a7cf38